### PR TITLE
fix(google console errors): Remove comments

### DIFF
--- a/src/quickfield.coffee
+++ b/src/quickfield.coffee
@@ -89,16 +89,6 @@ createBuilder = (settingOverrides, templateOverrides)->
 
 
 import TextField from './fields/text'
-# import TextareaField from './fields/textarea'
-# import NumberField from './fields/number'
-# import SelectField from './fields/select'
-# import ChoiceField from './fields/choice'
-# import TruefalseField from './fields/truefalse'
-# import ToggleField from './fields/toggle'
-# import GroupField from './fields/group'
-# import RepeaterField from './fields/repeater'
-# import FileField from './fields/file'
-# import CheckboxField from './fields/checkbox'
 
 quickfield = createBuilder()
 quickfield.register 'text', TextField


### PR DESCRIPTION
Somehow google crawler picks up these comments from the code and interprets them as URLs.
So we get 404 in Google console for pages like these:
```
https://saaslist.com/blog/2017/12/27/gmail-crm-integration/fields/checkbox
https://saaslist.com/blog/fields/toggle
https://saaslist.com/blog/united-customer-service/fields/truefalse
https://saaslist.com/reviews/constant-contact/fields/choice
https://saaslist.com/reviews/constant-contact/fields/number
```